### PR TITLE
Add Spotify Beats Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ node_modules/
 # Task files
 tasks.json
 tasks/ 
+**/.claude/settings.local.json

--- a/Actual.md
+++ b/Actual.md
@@ -8,4 +8,4 @@ i have this embed from spotify
 
 
 
-make it embed in website
+make it embed in website 

--- a/Actual.md
+++ b/Actual.md
@@ -1,19 +1,11 @@
-
-i need  some json place for these buttons  in frontend app:
-
- "Open Control Panel", 
-"Enter Full Screen", 
-
- "Back",
- "Timer",
- "Interval", 
- "Round Duration", 
-
-"Next Item", 
-"Decrease Interval", 
-"Increase Interval", 
-"Pause", "position": 
- "Reset Round"
+i want to have spotify tab in main page- to play beats;
+from one playlist: 
 
 
- and i need their polish versions
+i have this embed from spotify
+
+<iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/5JyZOh3sXa75Lsm8kyS1rI?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+
+
+
+make it embed in website

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import Home from './components/Home/Home';
 import WordMode from './components/BattleMode/WordModes/WordMode';
 import TopicMode from './components/BattleMode/WordModes/TopicMode';
 import ImagesMode from './components/BattleMode/ImagesMode/ImagesMode';
+import BeatsMode from './components/BattleMode/BeatsMode/BeatsMode';
 import ReportFeedback from './components/UserManagement/ReportFeedback';
 import { BackButton } from './components/Navigation/Buttons';
 import Account from './components/Account/Account';
@@ -26,6 +27,7 @@ function App() {
           <Route path="/word-mode" element={<WordMode />} />
           <Route path="/topic-mode" element={<TopicMode />} />
           <Route path="/image-mode" element={<ImagesMode />} />
+          <Route path="/beats-mode" element={<BeatsMode />} />
           <Route path="/report-feedback" element={<ReportFeedback />} />
           <Route path="/account" element={<Account />} />
           <Route path="/battle-judging" element={<BattleJudging />} />

--- a/frontend/src/components/BattleMode/BeatsMode/BeatsMode.js
+++ b/frontend/src/components/BattleMode/BeatsMode/BeatsMode.js
@@ -1,0 +1,122 @@
+// BeatsMode.js
+import React, { useState } from 'react';
+import { FullScreen } from 'react-full-screen';
+import useTranslation from '../../../config/useTranslation';
+
+const BeatsMode = () => {
+  const { t } = useTranslation();
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [handle, setHandle] = useState(null);
+
+  const toggleFullScreen = () => {
+    if (handle) {
+      if (isFullScreen) {
+        handle.exit();
+      } else {
+        handle.enter();
+      }
+      setIsFullScreen(!isFullScreen);
+    }
+  };
+
+  return (
+    <FullScreen handle={{ enter: () => {}, exit: () => {}, active: isFullScreen, onChange: setIsFullScreen }} ref={setHandle}>
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100vw',
+        height: '100vh',
+        overflow: 'hidden',
+        backgroundColor: '#1a1a1a',
+        color: 'white',
+        padding: '20px',
+        boxSizing: 'border-box'
+      }}>
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flex: 1,
+          maxWidth: '900px',
+          margin: '0 auto',
+          width: '100%'
+        }}>
+          <h1 style={{ marginBottom: '20px', textAlign: 'center' }}>{t('beatsModeTitle') || 'Freestyle Beats'}</h1>
+          
+          <div style={{ marginBottom: '20px', textAlign: 'center' }}>
+            <p style={{ fontSize: '16px', lineHeight: '1.5', marginBottom: '15px' }}>
+              {t('beatsModeDescription') || 'Use these beats for your freestyle practice sessions.'}
+            </p>
+            <p style={{ fontSize: '14px', backgroundColor: '#333', padding: '10px', borderRadius: '5px', marginBottom: '20px' }}>
+              {t('thirdPartyCookiesWarning') || 'Note: You may need to allow third-party cookies for the Spotify player to work properly.'}
+            </p>
+          </div>
+          
+          <div style={{ width: '100%', height: '500px', maxWidth: '100%' }}>
+            <iframe
+              src="https://open.spotify.com/embed/playlist/5JyZOh3sXa75Lsm8kyS1rI?utm_source=generator"
+              width="100%"
+              height="100%"
+              frameBorder="0"
+              allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+              loading="lazy"
+              title="Cypher Arena Freestyle Beats"
+              style={{ borderRadius: '8px' }}
+            ></iframe>
+          </div>
+          
+          <div style={{ marginTop: '20px', textAlign: 'center' }}>
+            <a
+              href="https://open.spotify.com/playlist/5JyZOh3sXa75Lsm8kyS1rI"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: 'inline-block',
+                backgroundColor: '#1DB954', // Spotify green
+                color: 'white',
+                padding: '10px 20px',
+                borderRadius: '30px',
+                textDecoration: 'none',
+                fontWeight: 'bold',
+                marginTop: '15px'
+              }}
+            >
+              {t('openInSpotify') || 'Open in Spotify'} ↗
+            </a>
+          </div>
+        </div>
+        
+        <div style={{
+          position: 'fixed',
+          top: 10,
+          right: 10,
+          zIndex: 1000,
+          transition: 'opacity 0.3s ease-in-out',
+          opacity: isFullScreen ? 0 : 1,
+        }}
+        onMouseEnter={(e) => isFullScreen && (e.currentTarget.style.opacity = '1')}
+        onMouseLeave={(e) => isFullScreen && (e.currentTarget.style.opacity = '0')}
+        >
+          <button
+            onClick={toggleFullScreen}
+            style={{
+              display: 'block',
+              padding: '10px',
+              backgroundColor: '#4CAF50',
+              color: 'white',
+              border: 'none',
+              borderRadius: '5px',
+              cursor: 'pointer',
+              width: '100%'
+            }}
+          >
+            {isFullScreen ? (t('exitFullScreen') || 'Exit Fullscreen') : (t('enterFullScreen') || 'Enter Fullscreen')}
+          </button>
+        </div>
+      </div>
+    </FullScreen>
+  );
+};
+
+export default BeatsMode;

--- a/frontend/src/components/Home/Home.js
+++ b/frontend/src/components/Home/Home.js
@@ -40,13 +40,14 @@ function Home() {
         <button onClick={() => navigate('/image-mode')}>{t('imagesMode')}</button>
         <button onClick={() => navigate('/contrasting-mode')}>{t('contrastingMode')}</button>
         <button onClick={() => navigate('/topic-mode')}>{t('topicMode')}</button>
-        
+        <button onClick={() => navigate('/beats-mode')}>{t('beats')}</button>
+
         {/* <h2>Tryb Ocenianie Walki</h2> */}
         {/* <button onClick={() => navigate('/battle-judging')}>Ocenianie Pojedynczej Walki</button> */}
-        
+
         {/* <h2>Tryb Zorganizuj Bitwę</h2> */}
         {/* <button onClick={() => navigate('/organize-battle')}>Zorganizuj Bitwę</button> */}
-        
+
         <button onClick={() => navigate('/report-feedback')}>{t('giveFeedback')}</button>
       </div>
     </div>

--- a/frontend/src/config/translations.js
+++ b/frontend/src/config/translations.js
@@ -27,6 +27,14 @@ const translations = {
     contrastingMode: "Rap Avatar Duel",
     topicMode: "Topic Generator",
     giveFeedback: "Give Feedback!",
+    beats: "Beats",
+    spotifyLoginNote: "Note: You'll need to allow third-party cookies in your browser settings and be logged into Spotify to play full tracks. Otherwise, only 30-second previews will be available.",
+    openInSpotify: "Open in Spotify",
+
+    // Beats Mode
+    beatsModeTitle: "Freestyle Beats",
+    beatsModeDescription: "Use these beats for your freestyle practice sessions.",
+    thirdPartyCookiesWarning: "Note: You'll need to allow third-party cookies in your browser settings and be logged into Spotify to play full tracks. Otherwise, only 30-second previews will be available.",
     
     // Exit fullscreen
     exitFullScreen: "Exit Full Screen",
@@ -65,6 +73,14 @@ const translations = {
     contrastingMode: "Rap Avatar Duel",
     topicMode: "Temator",
     giveFeedback: "Daj Feedback!",
+    beats: "Beaty",
+    spotifyLoginNote: "Uwaga: Aby odtwarzać pełne utwory, musisz zezwolić na pliki cookie stron trzecich w ustawieniach przeglądarki i być zalogowanym do Spotify. W przeciwnym razie dostępne będą tylko 30-sekundowe fragmenty.",
+    openInSpotify: "Otwórz w Spotify",
+
+    // Beats Mode
+    beatsModeTitle: "Beaty Freestyle",
+    beatsModeDescription: "Użyj tych beatów do swoich sesji freestyle.",
+    thirdPartyCookiesWarning: "Uwaga: Aby odtwarzać pełne utwory, musisz zezwolić na pliki cookie stron trzecich w ustawieniach przeglądarki i być zalogowanym do Spotify. W przeciwnym razie dostępne będą tylko 30-sekundowe fragmenty.",
     
     // Exit fullscreen
     exitFullScreen: "Wyłącz Pełny Ekran",

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -267,3 +267,57 @@
     padding: 10px;
     text-align: center;
   } */
+
+/* Spotify section styles */
+.spotify-section {
+  margin-top: 40px;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.spotify-section h2 {
+  color: #ffdd57;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.spotify-info {
+  text-align: center;
+  margin-bottom: 15px;
+  font-size: 0.9rem;
+  color: #ffdd57;
+  padding: 5px;
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.5);
+  max-width: 800px;
+  margin: 0 auto 15px;
+}
+
+.spotify-embed {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.spotify-direct-link {
+  text-align: center;
+  margin-top: 15px;
+}
+
+.spotify-direct-link a {
+  display: inline-block;
+  background-color: #1DB954; /* Spotify green */
+  color: white;
+  padding: 10px 20px;
+  border-radius: 25px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background-color 0.3s, transform 0.3s;
+}
+
+.spotify-direct-link a:hover {
+  background-color: #1ed760;
+  transform: translateY(-2px);
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- Added a dedicated Beats Mode tab with Spotify playlist integration
- Created new BeatsMode component with fullscreen capability
- Added translations for the new feature in English and Polish
- Updated navigation to include the Beats Mode
- Added helpful instructions about third-party cookies for Spotify playback

## Test plan
- Verify Beats Mode is accessible from the home page
- Check that the Spotify embed loads correctly
- Test fullscreen functionality
- Confirm all translations work properly

🤖 Generated with [Claude Code](https://claude.ai/code)